### PR TITLE
强制编辑框文本在单词内断行

### DIFF
--- a/wikiplus.css
+++ b/wikiplus.css
@@ -97,6 +97,7 @@
 	-moz-user-select: text;
 }
 #Wikiplus-Quickedit {
+	word-break: break-all;
 	width: 100%;
 	min-height: 500px;
 }


### PR DESCRIPTION
ref、网址和长单词等自动换到下一行会造成误解，比如是不是回车了，前面有没有空格也不方便看出来。