### PR TITLE
对非自确用户在前台显示错误提示

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -932,6 +932,10 @@ $(function() {
              */
             initQuickEdit(callback = {}) {
                 var self = this;
+                var checkRight = function() {
+                    !mw.config.get('wgUserGroups').includes('autoconfirmed') && !mw.config.get('wgUserGroups').includes('confirmed') && (new MoeNotification).create.error(getErrorInfo('not_autoconfirmed_user').message);
+                    throwError('not_autoconfirmed_user');
+                }
                 callback.success = callback.success || new Function();
                 callback.fail = callback.fail || new Function();
                 if (!(mw.config.get('wgIsArticle') && mw.config.get('wgAction') === 'view' && mw.config.get('wgIsProbablyEditable'))) {
@@ -951,6 +955,7 @@ $(function() {
                 if ($('#ca-edit').length > 0 && $('#Wikiplus-Edit-TopBtn').length === 0) {
                     mw.config.get('skin') === 'minerva' ? $('#ca-edit').parent().after(topBtn) : $('#ca-edit').after(topBtn);
                     $('#Wikiplus-Edit-TopBtn').click(function() {
+                        checkRight();
                         self.initQuickEditInterface($(this)); //直接把DOM传递给下一步
                     });
                 } else if ($('#ca-edit').length === 0) {
@@ -997,6 +1002,7 @@ $(function() {
                         }
                     });
                     $('.Wikiplus-Edit-SectionBtn').click(function() {
+                        checkRight();
                         self.initQuickEditInterface($(this)); //直接把DOM传递给下一步
                     });
                 }
@@ -1639,7 +1645,7 @@ $(function() {
             initRecentChangesPageFunctions() {}
             initAdvancedFunctions() {}
             constructor() {
-                this.version = '2.3.7';
+                this.version = '2.3.8';
                 this.langVersion = '212';
                 this.releaseNote = '修正一些问题';
                 this.notice = new MoeNotification();

--- a/src/Main.js
+++ b/src/Main.js
@@ -979,7 +979,6 @@ $(function() {
                             } else {
                                 var regex = new RegExp(`${mw.config.get('wgArticlePath').replace('$1', '')}(.+?)\\?`);
                                 if (editURL.match(regex)) {
-                                    $('.mw-editsection-divider').css('visibility', 'hidden');
                                     sectionTargetName = decodeURIComponent(editURL.match(regex)[1]);
                                 } else {
                                     throwError('fail_to_init_quickedit');

--- a/src/Main.js
+++ b/src/Main.js
@@ -933,8 +933,10 @@ $(function() {
             initQuickEdit(callback = {}) {
                 var self = this;
                 var checkRight = function() {
-                    !mw.config.get('wgUserGroups').includes('autoconfirmed') && !mw.config.get('wgUserGroups').includes('confirmed') && (new MoeNotification).create.error(getErrorInfo('not_autoconfirmed_user').message);
-                    throwError('not_autoconfirmed_user');
+                    if (!mw.config.get('wgUserGroups').includes('autoconfirmed') && !mw.config.get('wgUserGroups').includes('confirmed')) {
+                        (new MoeNotification).create.error(getErrorInfo('not_autoconfirmed_user').message);
+                        throwError('not_autoconfirmed_user');
+                    }
                 }
                 callback.success = callback.success || new Function();
                 callback.fail = callback.fail || new Function();

--- a/wikiplus.css
+++ b/wikiplus.css
@@ -160,6 +160,9 @@
 .mw-editsection-divider {
 	display: inline !important;
 }
+.skin-minerva .mw-editsection-divider {
+	visibility: hidden;
+}
 .skin-minerva #Wikiplus-Quickedit-Preview-Submit, .skin-minerva #Wikiplus-Quickedit-Submit, .skin-minerva #Wikiplus-Quickedit-Summary-Input, .skin-minerva .Wikiplus-InterBox-Input {
 	all: revert;
 }


### PR DESCRIPTION
为什么在按钮插入之后点按钮的时候才放个checkRight呢，因为对普通用户来说，这样可以说明Wikiplus有加载，只是因为权限不足才不能用。~~真是清真的方法呢~~