### PR TITLE
允许自定义编辑摘要函数返回空的编辑摘要

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ $(async () => {
             sectionTargetName: targetPageName,
         });
         const summary =
-            customSummary ||
+            customSummary ??
             (sectionName
                 ? `/* ${sectionName} */ ${i18n.translate("default_summary_suffix")}`
                 : i18n.translate("default_summary_suffix"));

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -14,7 +14,7 @@ class Settings {
                     if (customSettingFunction()(w) === true) {
                         return;
                     } else {
-                        return customSettingFunction()(w) || settings[key];
+                        return customSettingFunction()(w) ?? settings[key];
                     }
                 } catch (e) {
                     return settings[key];


### PR DESCRIPTION
目前 `customSummary` 函数如果返回空值的话会被忽略（可能并不是故意为之？）。此 PR 使得自定义编辑摘要函数返回的空编辑摘要会被接受，而非回滚至默认编译摘要。