### PR TITLE
fix: temporal dead zone (TDZ)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -149,11 +149,11 @@ $(async () => {
     const handleSimpleRedirectButtonClicked = async () => {
         UI.showSimpleRedirectPanel({
             onEdit: async ({ title, summary, forceOverwrite = false }) => {
+                const page = await getPage({ title });
+                const currentPageName = Constants.currentPageName;
                 if (summary == "") {
                     summary = i18n.translate("redirect_from_summary", [title, currentPageName]);
                 }
-                const page = await getPage({ title });
-                const currentPageName = Constants.currentPageName;
                 const payload = {
                     content: `#REDIRECT [[${currentPageName}]]`,
                     config: {


### PR DESCRIPTION
the constant currentPageName is used before its initialization

![QQ20250112-181859](https://github.com/user-attachments/assets/01c19f71-20aa-4a1b-bed0-6353e26b90fb)
