### PR TITLE
feat: check content model before creating the page redirect

### DIFF
--- a/src/core/page.js
+++ b/src/core/page.js
@@ -10,11 +10,14 @@ class Page {
     inited = false;
     isNewPage = false;
 
+    contentmodel = "wikitext";
+
     sectionCache = {};
 
     /**
      * @param {params.title} 页面标题 Page Name (optional)
      * @param {params.revisionId} 页面修订编号 Revision Id
+     * @param {params.contentmodel} 页面内容模型 Content Model
      */
     constructor({ title, revisionId }) {
         this.title = title;
@@ -28,7 +31,7 @@ class Page {
      * @param {string} editToken (optional) 如果提供了editToken，将不会再获取
      */
     async init({ editToken = "" } = {}) {
-        const promiseArr = [this.getTimestamp()];
+        const promiseArr = [this.getTimestamp(), this.getContentModel()];
         if (!editToken) {
             promiseArr.push(this.getEditToken());
         }
@@ -68,6 +71,20 @@ class Page {
             this.revisionId = revisionId;
             this.isNewPage = false;
         }
+    }
+
+    /**
+     * 获得页面内容模型
+     *
+     * @param {Object} config
+     * @param {string} config.revisionId
+     */
+    async getContentModel() {
+        const { contentmodel } = await Wiki.getPageInfo({
+            revisionId: this.revisionId,
+            title: this.title,
+        });
+        this.contentmodel = contentmodel || "wikitext";
     }
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -151,11 +151,39 @@ $(async () => {
             onEdit: async ({ title, summary, forceOverwrite = false }) => {
                 const page = await getPage({ title });
                 const currentPageName = Constants.currentPageName;
+                const contentmodel = page.contentmodel;
                 if (summary == "") {
                     summary = i18n.translate("redirect_from_summary", [title, currentPageName]);
                 }
+                const content = (() => {
+                    let content;
+                    switch (contentmodel) {
+                        case "javascript":
+                            content = `/* #REDIRECT */mw.loader.load("${location.protocol}//${
+                                location.host
+                            }${Constants.scriptPath}/index.php?title=${mw.util.wikiUrlencode(
+                                currentPageName
+                            )}&action=raw&ctype=text/javascript");`;
+                            break;
+                        case "css":
+                            content = `/* #REDIRECT */@import url(${location.protocol}//${
+                                location.host
+                            }${Constants.scriptPath}/index.php?title=${mw.util.wikiUrlencode(
+                                currentPageName
+                            )}&action=raw&ctype=text/css);`;
+                            break;
+                        case "Scribunto":
+                            content = `return require [[${currentPageName}]]`;
+                            break;
+                        case "wikitext":
+                        default:
+                            content = `#REDIRECT [[${currentPageName}]]`;
+                            break;
+                    }
+                    return content;
+                })();
                 const payload = {
-                    content: `#REDIRECT [[${currentPageName}]]`,
+                    content: content,
                     config: {
                         summary,
                     },

--- a/src/services/wiki.js
+++ b/src/services/wiki.js
@@ -64,7 +64,7 @@ class Wiki {
                 if (Object.keys(response.query.pages)[0] === "-1") {
                     // 不存在这一页面
                     // Page not found.
-                    this.pageInfoCache[title] = { contentmodel: contentmodel };
+                    this.pageInfoCache[title] = { contentmodel };
                     return {
                         contentmodel: contentmodel,
                     };

--- a/src/services/wiki.js
+++ b/src/services/wiki.js
@@ -59,9 +59,9 @@ class Wiki {
             }
             const response = await requests.get(params);
             if (response.query && response.query.pages) {
-                const contentmodel =
-                    response.query.pages[Object.keys(response.query.pages)[0]].contentmodel;
-                if (Object.keys(response.query.pages)[0] === "-1") {
+                const pageKey = Object.keys(response.query.pages)[0];
+                const contentmodel = response.query.pages[pageKey].contentmodel;
+                if (pageKey === "-1") {
                     // 不存在这一页面
                     // Page not found.
                     this.pageInfoCache[title] = { contentmodel };
@@ -69,8 +69,7 @@ class Wiki {
                         contentmodel: contentmodel,
                     };
                 }
-                const pageInfo =
-                    response.query.pages[Object.keys(response.query.pages)[0]].revisions[0];
+                const pageInfo = response.query.pages[pageKey].revisions[0];
                 if (title) {
                     this.pageInfoCache[title] = { ...pageInfo, contentmodel };
                 }

--- a/src/services/wiki.js
+++ b/src/services/wiki.js
@@ -72,8 +72,7 @@ class Wiki {
                 const pageInfo =
                     response.query.pages[Object.keys(response.query.pages)[0]].revisions[0];
                 if (title) {
-                    this.pageInfoCache[title] = pageInfo;
-                    this.pageInfoCache[title].contentmodel = contentmodel;
+                    this.pageInfoCache[title] = { ...pageInfo, contentmodel };
                 }
                 return {
                     timestamp: pageInfo.timestamp,

--- a/src/services/wiki.js
+++ b/src/services/wiki.js
@@ -1,7 +1,6 @@
 import requests from "../utils/requests";
 import Log from "../utils/log";
 import i18n from "../utils/i18n";
-import Constants from "../utils/constants";
 
 class Wiki {
     pageInfoCache = {};
@@ -34,6 +33,7 @@ class Wiki {
      * Get the timestamp of the last revision of page specified.
      * @param {params.string} title 页面名 / Pagename
      * @param {params.revisionId} revisionId 修订版本号 / Revision ID
+     * @param {params.contentmodel} contentmodel 内容模型 / Content Model
      * @returns {Promise<string>}
      */
     async getPageInfo({ title, revisionId }) {
@@ -52,25 +52,33 @@ class Wiki {
                     return {
                         timestamp: this.pageInfoCache[title].timestamp,
                         revisionId: this.pageInfoCache[title].revid,
+                        contentmodel: this.pageInfoCache[title].contentmodel,
                     };
                 }
                 params.titles = title;
             }
             const response = await requests.get(params);
             if (response.query && response.query.pages) {
+                const contentmodel =
+                    response.query.pages[Object.keys(response.query.pages)[0]].contentmodel;
                 if (Object.keys(response.query.pages)[0] === "-1") {
                     // 不存在这一页面
                     // Page not found.
-                    return {};
+                    this.pageInfoCache[title] = { contentmodel: contentmodel };
+                    return {
+                        contentmodel: contentmodel,
+                    };
                 }
                 const pageInfo =
                     response.query.pages[Object.keys(response.query.pages)[0]].revisions[0];
                 if (title) {
                     this.pageInfoCache[title] = pageInfo;
+                    this.pageInfoCache[title].contentmodel = contentmodel;
                 }
                 return {
                     timestamp: pageInfo.timestamp,
                     revisionId: pageInfo.revid,
+                    contentmodel: contentmodel,
                 };
             }
         } catch (e) {


### PR DESCRIPTION
本PR基于MediaWiki有关重定向的特性：

- 若是“javascript”“css”，可以采用“重定向注释+固定格式的加载URL”格式做重定向；
- 若是“Scribunto”，可以采用`return require [[标题]]`作重定向（兼容性：MW 1.43+）
- 若是“wikitext”，仍是原来的重定向格式

为了配合这个判断，新增了一个查询页面内容模型的函数。