### PR TITLE
Make QuickEdit button collapsible

### DIFF
--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -157,7 +157,7 @@ class UI {
      * Insert QuickEdit button besides page edit button.
      */
     insertTopQuickEditEntry(onClick) {
-        const topBtn = $("<li>").attr("id", "Wikiplus-Edit-TopBtn").attr("class", "mw-list-item");
+        const topBtn = $("<li>").attr("id", "Wikiplus-Edit-TopBtn").attr("class", "mw-list-item collapsible");
         const topBtnLink = $("<a>")
             .attr("href", "javascript:void(0)")
             .text(`${i18n.translate("quickedit_topbtn")}`);


### PR DESCRIPTION
This PR makes the QuickEdit button at the top collapsible, matching the behavior of the vanilla MediaWiki buttons